### PR TITLE
Amended hack to set initial size correctly

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -103,7 +103,11 @@ namespace Xamarin.Forms.Platform.UWP
 #if HAS_UNO
 			// The ActualWith/ActualHeight of _container are not yet known. We wait for a layout pass
 			// then we update the bounds.
-			var unused =_page.Dispatcher.RunAsync(CoreDispatcherPriority.High, () => UpdateBounds());
+			var unused = _page.Dispatcher.RunAsync(CoreDispatcherPriority.High, () =>
+			{
+				UpdateBounds();
+				UpdatePageSizes();
+			});
 #endif
 
 			InitializeStatusBar();


### PR DESCRIPTION
### Description of Change ###
Call UpdatePageSizes(), as is done in SizeChanged callback. Workaround for ActualSize properties not being set at same time on Uno as UWP.

<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
