### PR TITLE
Add Xamarin.Forms.Xaml to linker exclusions

### DIFF
--- a/Xamarin.Forms.Platform.UAP/LinkerConfig.wasm.xml
+++ b/Xamarin.Forms.Platform.UAP/LinkerConfig.wasm.xml
@@ -1,4 +1,5 @@
 ﻿<linker>
   <assembly fullname="Xamarin.Forms.Platform.Uno" />
   <assembly fullname="Uno.Foundation"/>
+  <assembly fullname="Xamarin.Forms.Xaml"/>
 </linker>


### PR DESCRIPTION
The Xamarin.Forms engine requires the use of internal types through reflection, making some types fail to load.

Related: https://github.com/unoplatform/uno/issues/2326
